### PR TITLE
REFACTOR: changed NetworkProvider visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,6 @@ mod client;
 pub use client::Client;
 
 mod networking;
+pub use networking::NetworkProvider;
 
 mod error;


### PR DESCRIPTION
Make the `NetworkProvider` trait publicly visible for its usage in `pchain-client-cli` repository.